### PR TITLE
fix(namespace): multiple packages

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -1,17 +1,11 @@
 <?php
 
 $configuration = json_decode(
-    file_get_contents('conductor.json'),
+    file_get_contents(__DIR__ . '/' . 'conductor.json'),
     true
 );
 
 $namespaces = $configuration['autoload']['psr-4'];
-
-function fqcnToPath(string $fqcn, string $prefix) {
-    $relativeClass = ltrim($fqcn, $prefix);
-
-    return str_replace('\\', '/', $relativeClass) . '.php';
-}
 
 spl_autoload_register(function (string $class) use ($namespaces) {
     $prefix = strtok($class, '\\') . '\\';
@@ -20,8 +14,10 @@ spl_autoload_register(function (string $class) use ($namespaces) {
     // Return and hope some other autoloader handles it.
     if (!array_key_exists($prefix, $namespaces)) return;
 
-    $baseDirectory = $namespaces[$prefix];
-    $path = fqcnToPath($class, $prefix);
+    if (substr($class, 0, strlen($prefix)) == $prefix) {
+        $relativeClass = substr($class, strlen($prefix));
+    }
+    $path = str_replace('\\', '/', $relativeClass) . '.php';
 
-    require $baseDirectory . '/' . $path;
+    require_once $baseDirectory . '/' . $path;
 });


### PR DESCRIPTION
***
# Example
## Formerly
+ Project (namespace)
  + sub-project (sub-namespace)
      +  package (sub-2-namespace)
      + ...
      + package-n (sub-2-namespace-n)
  + ...
  + sub-project-n (sub-namespace-n)
      +  package (sub-2-namespace)
      + ...
      + package-n (sub-2-namespace-n)
+ autoloader.php

```json
{
    "autoload": {
        "psr-4": {
            "namespace\\": "project/"
        }
    }
}
```

## Currently
+ Project
  + project (namespace)
    + src
      +  package (sub-namespace)
      + ...
      + package-n (sub-namespace-n)
  + ...
  + project-n (namespace-n)
    + src
      +  package (sub-namespace)
      + ...
      + package-n (sub-namespace-n)
  + autoloader.php
```json
{
    "autoload": {
        "psr-4": {
            "namespace\\": "project/src/",
            "namespace-n\\": "project-n/src/"
        }
    }
}
```

***